### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
   release:
     name: Create zkgroup release
     # This ensures that this job only runs on git tags
-    #if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - build-zkgroup
     runs-on: ubuntu-latest
@@ -77,13 +77,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: build-artifacts
-
-      - name: List artifact download output
-        run: |
-          ls -la build-artifacts
-          ls -la build-artifacts/zkgroup-aarch64-unknown-linux-gnu
-          ls -la build-artifacts/zkgroup-armv7-unknown-linux-gnueabihf
-          ls -la build-artifacts/zkgroup-x86_64-unknown-linux-gnu
 
       - name: Create draft GitHub release page
         id: create_release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload built artifact
         uses: actions/upload-artifact@v2
         with:
-          name: zkgroup-debug-${{ matrix.target }}
+          name: zkgroup-${{ matrix.target }}
           path: lib/zkgroup/target/${{ matrix.target }}/debug/libzkgroup.so
           if-no-files-found: error
 
@@ -78,6 +78,9 @@ jobs:
         with:
           path: build-artifacts
 
+      - name: List artifact download output
+        run: ls -la build-artifacts
+
       - name: Create draft GitHub release page
         id: create_release
         uses: actions/create-release@v1
@@ -98,8 +101,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/zkgroup-debug-x86_64-unknown-linux-gnu
-          asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}
+          asset_path: ./build-artifacts/zkgroup-x86_64-unknown-linux-gnu.zip
+          asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Add zkgroup to release (aarch64)
@@ -108,8 +111,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/zkgroup-debug-aarch64-unknown-linux-gnu
-          asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}
+          asset_path: ./build-artifacts/zkgroup-aarch64-unknown-linux-gnu.zip
+          asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Add zkgroup to release (armv7)
@@ -118,6 +121,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/zkgroup-debug-armv7-unknown-linux-gnueabihf
-          asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}
+          asset_path: ./build-artifacts/zkgroup-armv7-unknown-linux-gnueabihf.zip
+          asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,9 +105,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/zkgroup-x86_64-unknown-linux-gnu.zip
-          asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}.zip
-          asset_content_type: application/zip
+          asset_path: ./build-artifacts/zkgroup-x86_64-unknown-linux-gnu/libzkgroup.so
+          asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}.so
+          asset_content_type: application/octet-stream
 
       - name: Add zkgroup to release (aarch64)
         uses: actions/upload-release-asset@v1
@@ -115,9 +115,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/zkgroup-aarch64-unknown-linux-gnu.zip
-          asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}.zip
-          asset_content_type: application/zip
+          asset_path: ./build-artifacts/zkgroup-aarch64-unknown-linux-gnu/libzkgroup.so
+          asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}.so
+          asset_content_type: application/octet-stream
 
       - name: Add zkgroup to release (armv7)
         uses: actions/upload-release-asset@v1
@@ -125,6 +125,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/zkgroup-armv7-unknown-linux-gnueabihf.zip
-          asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}.zip
-          asset_content_type: application/zip
+          asset_path: ./build-artifacts/zkgroup-armv7-unknown-linux-gnueabihf/libzkgroup.so
+          asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}.so
+          asset_content_type: application/octet-stream

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ on: [push]
 name: CI
 
 jobs:
-  build:
+  build-zkgroup:
     name: build zkgroup
     strategy:
       matrix:
@@ -55,6 +55,8 @@ jobs:
     name: Create zkgroup release
     # This ensures that this job only runs on git tags
     #if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build-zkgroup
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ on: [push]
 name: CI
 
 jobs:
-  build-zkgroup:
+  build:
     name: build zkgroup
     strategy:
       matrix:
@@ -50,3 +50,70 @@ jobs:
           name: zkgroup-debug-${{ matrix.target }}
           path: lib/zkgroup/target/${{ matrix.target }}/debug/libzkgroup.so
           if-no-files-found: error
+
+  release:
+    name: Create zkgroup release
+    # This ensures that this job only runs on git tags
+    #if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get git tag version
+        id: get_version
+        uses: battila7/get-version-action@v2
+
+      - name: Set git tag version
+        run: |
+          echo "VERSION=${{ steps.get_version.outputs.version }}" >> $GITHUB_ENV
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: build-artifacts
+
+      - name: Create draft GitHub release page
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          body: |
+            -
+            -
+          draft: true
+          prerelease: false
+
+      - name: Add zkgroup to release (x86_64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build-artifacts/x86_64-unknown-linux-gnu
+          asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}
+          asset_content_type: application/zip
+
+      - name: Add zkgroup to release (aarch64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build-artifacts/aarch64-unknown-linux-gnu
+          asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}
+          asset_content_type: application/zip
+
+      - name: Add zkgroup to release (armv7)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build-artifacts/armv7-unknown-linux-gnueabihf
+          asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}
+          asset_content_type: application/zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Get git tag version
         id: get_version
@@ -96,7 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build-artifacts/x86_64-unknown-linux-gnu
+          asset_path: build-artifacts/zkgroup-debug-x86_64-unknown-linux-gnu
           asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}
           asset_content_type: application/zip
 
@@ -106,7 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build-artifacts/aarch64-unknown-linux-gnu
+          asset_path: build-artifacts/zkgroup-debug-aarch64-unknown-linux-gnu
           asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}
           asset_content_type: application/zip
 
@@ -116,6 +118,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build-artifacts/armv7-unknown-linux-gnueabihf
+          asset_path: build-artifacts/zkgroup-debug-armv7-unknown-linux-gnueabihf
           asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}
           asset_content_type: application/zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -98,7 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build-artifacts/zkgroup-debug-x86_64-unknown-linux-gnu
+          asset_path: ./build-artifacts/zkgroup-debug-x86_64-unknown-linux-gnu
           asset_name: libzkgroup-linux_x86_64-${{ env.VERSION }}
           asset_content_type: application/zip
 
@@ -108,7 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build-artifacts/zkgroup-debug-aarch64-unknown-linux-gnu
+          asset_path: ./build-artifacts/zkgroup-debug-aarch64-unknown-linux-gnu
           asset_name: libzkgroup-linux-aarch64-${{ env.VERSION }}
           asset_content_type: application/zip
 
@@ -118,6 +118,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build-artifacts/zkgroup-debug-armv7-unknown-linux-gnueabihf
+          asset_path: ./build-artifacts/zkgroup-debug-armv7-unknown-linux-gnueabihf
           asset_name: libzkgroup-linux-armv7-${{ env.VERSION }}
           asset_content_type: application/zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ name: CI
 
 jobs:
   build-zkgroup:
-    name: build zkgroup
+    name: Build zkgroup
     strategy:
       matrix:
         target:
@@ -79,7 +79,11 @@ jobs:
           path: build-artifacts
 
       - name: List artifact download output
-        run: ls -la build-artifacts
+        run: |
+          ls -la build-artifacts
+          ls -la build-artifacts/zkgroup-aarch64-unknown-linux-gnu
+          ls -la build-artifacts/zkgroup-armv7-unknown-linux-gnueabihf
+          ls -la build-artifacts/zkgroup-x86_64-unknown-linux-gnu
 
       - name: Create draft GitHub release page
         id: create_release


### PR DESCRIPTION
Automatically add the three libraries to a GitHub release page.

From the release we can later wget them and and use them in the axolotl CI build.