### PR TITLE
Adjust the zkgroup gitmodule as to specify git tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/zkgroup"]
 	path = lib/zkgroup
 	url = https://github.com/signalapp/zkgroup.git
+	tag = v0.9.0


### PR DESCRIPTION
This as the current main branch does not contain any source code anymore.

The currently added git module is now referring to an archived repository.

As to allow this to still work, this PR specifies the last version of the repo which still contained the source code.
